### PR TITLE
Update ptex-ng.ini and platex-ng.ini

### DIFF
--- a/texmf-dist/tex/uplatex/config/platex-ng.ini
+++ b/texmf-dist/tex/uplatex/config/platex-ng.ini
@@ -1,32 +1,9 @@
-%% for uplatex under ptex-ng (Unicode pLaTeX)
-%% written by Tono san
+%% for upLaTeX under Asiatic pTeX (platex-ng)
 %%
 \begingroup  \catcode`\{=1  \catcode`\}=2%
-   \immediate\write20{<<< making "uplatex with Babel" format >>>}
-   \def\platexTMP{%
-       \let\platexDUMP=\dump
-       \let\dump=\endinput
-   }
-   \expandafter
-\endgroup \platexTMP
-%
-%%  \scrollmode
-\input uplatex.ltx
-%
-\begingroup  \makeatletter%
-   \@temptokena=\expandafter{\platexBANNER}
-   \edef\platexTMP{%
-       \the\everyjob\noexpand\typeout{\the\@temptokena loaded.}%
-   }%
-   \everyjob=\expandafter{\platexTMP}%
-   \edef\platexTMP{%
-       \noexpand\let\noexpand\platexBANNER=\noexpand\@undefined
-       \noexpand\let\noexpand\dump=\noexpand\platexDUMP
-       \noexpand\let\noexpand\platexDUMP=\noexpand\@undefined
-       \noexpand\everyjob={\the\everyjob}%
-   }
-   \expandafter
-\endgroup \platexTMP
+  \immediate\write20{<<< making "uplatex with Babel" format >>>}
+\endgroup
+\scrollmode
 \input ptex-ng-config.tex
-\dump
+\input uplatex.ltx
 \endinput

--- a/texmf-dist/tex/uptex/config/ptex-ng.ini
+++ b/texmf-dist/tex/uptex/config/ptex-ng.ini
@@ -1,3 +1,4 @@
+%% for Asiatic pTeX (e-ptex-ng)
 \input ptex-ng-config.tex
 \input euptex.src
 \dump


### PR DESCRIPTION
TeX Live 2016 の環境に tltexjp をインストールしてみました。

```
$ sudo tlmgr repository add http://texlive.texjp.org/current/tltexjp tltexjp
$ sudo tlmgr pinning add tltexjp '*'
$ sudo tlmgr install pxdvi ptex-ng hiraprop
```

ptex-ng.fmt はできますが、platex-ng.fmt は失敗します。

```
! Undefined control sequence.
l.17    \@temptokena=\expandafter{\platexBANNER
                                               }
? 
! Emergency stop.
l.17    \@temptokena=\expandafter{\platexBANNER
                                               }
No pages of output.
```

これは「upLaTeX community ed. では特別の hyphen.cfg が不要になった」と関係しています。したがって、platex-ng.ini を新しくしました。
